### PR TITLE
Update Adldap.php to check for not found user

### DIFF
--- a/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
+++ b/src/Dsdevbe/LdapConnector/Adapter/Adldap.php
@@ -56,6 +56,10 @@ class Adldap implements LdapInterface
     {
         $user = $this->_ldap->search()->where('samaccountname', '=', $username)->first();
 
+        if (!$user) {
+            return null;
+        }
+
         return $this->mapDataToUserModel($user, $password);
     }
 


### PR DESCRIPTION
If the samaccountname does not exist, the user will be false. The false user is then attempted to pass into mapDataToUserModel which expects an instance of adLDAPUserModel causing an exception to be thrown.